### PR TITLE
ci: Use updated github actions for node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.25
 
@@ -35,13 +35,13 @@ jobs:
         run: make checksums
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: backup-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist/backup-${{ matrix.goos }}-${{ matrix.goarch }}
 
       - name: Upload SHA256 checksum files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: sha256-checksums-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist/*.sha256
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: dist
           merge-multiple: true


### PR DESCRIPTION
**Description**

Raise the versions used inside the release github workflow
